### PR TITLE
Update json_parser.cpp

### DIFF
--- a/src/json-api-core/json_parser.cpp
+++ b/src/json-api-core/json_parser.cpp
@@ -103,7 +103,7 @@ static char *print_number(pool* p,Value *item)
 }
 
 // Parse the input text into an unescaped cstring, and populate item.
-static const char firstByteMark[7] = { 0x00, 0x00, 0xC0, 0xE0, 0xF0, 0xF8, 0xFC };
+static const unsigned char firstByteMark[7] = { 0x00, 0x00, 0xC0, 0xE0, 0xF0, 0xF8, 0xFC };
 static const char *parse_string(pool* p,Value *item,const char *str)
 {
         const char *ptr=str+1;char *ptr2;char *out;int len=0;unsigned uc;


### PR DESCRIPTION
Hi,

It seems I have the -Wnarrowing flag by default on my g++ alpine (3.7). This causes the error below during the build of nginx:

```
/usr/src/nginx-openidc/src/json-api-core/json_parser.cpp: At global scope:
/usr/src/nginx-openidc/src/json-api-core/json_parser.cpp:106:81: error: narrowing conversion of '192' from 'int' to 'char' inside { } [-Wnarrowing]
 static const char firstByteMark[7] = { 0x00, 0x00, 0xC0, 0xE0, 0xF0, 0xF8, 0xFC };
                                                                                 ^
/usr/src/nginx-openidc/src/json-api-core/json_parser.cpp:106:81: error: narrowing conversion of '224' from 'int' to 'char' inside { } [-Wnarrowing]
/usr/src/nginx-openidc/src/json-api-core/json_parser.cpp:106:81: error: narrowing conversion of '240' from 'int' to 'char' inside { } [-Wnarrowing]
/usr/src/nginx-openidc/src/json-api-core/json_parser.cpp:106:81: error: narrowing conversion of '248' from 'int' to 'char' inside { } [-Wnarrowing]
/usr/src/nginx-openidc/src/json-api-core/json_parser.cpp:106:81: error: narrowing conversion of '252' from 'int' to 'char' inside { } [-Wnarrowing]
```
As char is platform dependant, not specifying the sign of char make number larger than 128 like 0xC0, 0xf0 ambiguous.
This PR fix this error build.